### PR TITLE
Add "Subscribe for updates" call-to-action at the end of posts

### DIFF
--- a/_includes/subscribe-cta.html
+++ b/_includes/subscribe-cta.html
@@ -1,5 +1,5 @@
 <div class="subscribe-cta">
-  <label>Subscribe for Updates</label>
+  <label for="voter-email">Subscribe for updates</label>
   <div id="subscribe-inputs">
     <input type="text" placeholder="Email Address" id="voter-email" /><input type="submit" value="Subscribe" id="btn-subscribe" onclick="subscribeButton()" />
   </div>

--- a/_includes/subscribe-cta.html
+++ b/_includes/subscribe-cta.html
@@ -1,0 +1,37 @@
+<div class="subscribe-cta">
+  <label>Subscribe for Updates</label>
+  <div id="subscribe-inputs">
+    <input type="text" placeholder="Email Address" id="voter-email" /><input type="submit" value="Subscribe" id="btn-subscribe" onclick="subscribeButton()" />
+  </div>
+  <p id="subscribe-confirmation" style="display: none"> &#10004; Subscribed</p>
+  <script>
+    function subscribeButton () {
+      return $.ajax({
+        url: 'https://api.liquid.vote/subscribe',
+        type: 'POST',
+        accept: 'application/json',
+        contentType: 'application/json',
+        data: JSON.stringify({
+          email: document.getElementById('voter-email').value
+        }),
+        processData: false,
+        success: function(response) {
+          console.log('subscribe response', response)
+          document.getElementById("subscribe-inputs").style.display = 'none'
+          document.getElementById("subscribe-confirmation").style.display = 'block'
+        },
+        error: function(error) {
+          console.log('subscribe error', error)
+          if (error.status === 409) {
+            // Already subscribed, show confirmation anyway
+            document.getElementById("subscribe-inputs").style.display = 'none'
+            document.getElementById("subscribe-confirmation").style.display = 'block'
+          }
+          if (error.status === 400) {
+            document.getElementById("voter-email").style.border = '1px solid red'
+          }
+        }
+      })
+    }
+  </script>
+</div>

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -96,6 +96,10 @@
         {% endif %}
       </article>
     </main>
+    <div class="subscribe-cta">
+      <label>Subscribe for Democracy</label>
+      <input type="text" placeholder="Email Address" /><input type="submit" value="Subscribe" />
+    </div>
     <div class="bottom-closer">
       <div class="background-closer-image" {%if site.cover %} style="background-image: url({{ site.cover }})"{% endif %}>
         Image

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -101,16 +101,13 @@
       <input type="text" placeholder="Email Address" id="voter-email" /><input type="submit" value="Subscribe" id="btn-subscribe" onclick="subscribeButton()" />
       <script>
         function subscribeButton () {
-          const voterEmail = document.getElementById('voter-email').value
-          console.log(voterEmail)
-
           return $.ajax({
             url: 'https://api.liquid.vote/subscribe',
             type: 'POST',
             accept: 'application/json',
             contentType: 'application/json',
             data: JSON.stringify({
-              email: voterEmail.value
+              email: document.getElementById('voter-email').value
             }),
             dataType: 'json',
             processData: false,

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -96,43 +96,7 @@
         {% endif %}
       </article>
     </main>
-    <div class="subscribe-cta">
-      <label>Subscribe for Updates</label>
-      <div id="subscribe-inputs">
-        <input type="text" placeholder="Email Address" id="voter-email" /><input type="submit" value="Subscribe" id="btn-subscribe" onclick="subscribeButton()" />
-      </div>
-      <p id="subscribe-confirmation" style="display: none"> &#10004; Subscribed</p>
-      <script>
-        function subscribeButton () {
-          return $.ajax({
-            url: 'https://api.liquid.vote/subscribe',
-            type: 'POST',
-            accept: 'application/json',
-            contentType: 'application/json',
-            data: JSON.stringify({
-              email: document.getElementById('voter-email').value
-            }),
-            processData: false,
-            success: function(response) {
-              console.log('subscribe response', response)
-              document.getElementById("subscribe-inputs").style.display = 'none'
-              document.getElementById("subscribe-confirmation").style.display = 'block'
-            },
-            error: function(error) {
-              console.log('subscribe error', error)
-              if (error.status === 409) {
-                // Already subscribed, show confirmation anyway
-                document.getElementById("subscribe-inputs").style.display = 'none'
-                document.getElementById("subscribe-confirmation").style.display = 'block'
-              }
-              if (error.status === 400) {
-                document.getElementById("voter-email").style.border = '1px solid red'
-              }
-            }
-          })
-        }
-      </script>
-    </div>
+    {% include subscribe-cta.html %}
     <div class="bottom-closer">
       <div class="background-closer-image" {%if site.cover %} style="background-image: url({{ site.cover }})"{% endif %}>
         Image

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -104,7 +104,7 @@
       <div class="inner">
         <h1 class="blog-title">{{ site.title }}</h1>
         <h2 class="blog-description">{{ site.description }}</h2>
-        <a href="/" class="btn">&#9668 &nbsp; Back home</a>
+        <a href="/" class="btn">&#9668 &nbsp; BACK HOME</a>
       </div>
     </div>
     {% include javascripts.html %}

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -98,7 +98,10 @@
     </main>
     <div class="subscribe-cta">
       <label>Subscribe for Democracy</label>
-      <input type="text" placeholder="Email Address" id="voter-email" /><input type="submit" value="Subscribe" id="btn-subscribe" onclick="subscribeButton()" />
+      <div id="subscribe-inputs">
+        <input type="text" placeholder="Email Address" id="voter-email" /><input type="submit" value="Subscribe" id="btn-subscribe" onclick="subscribeButton()" />
+      </div>
+      <p id="subscribe-confirmation" style="display: none"> &#10004; Subscribed</p>
       <script>
         function subscribeButton () {
           return $.ajax({
@@ -109,13 +112,14 @@
             data: JSON.stringify({
               email: document.getElementById('voter-email').value
             }),
-            dataType: 'json',
             processData: false,
-            success: function(res) {
-              console.log('res', res)
+            success: function(response) {
+              console.log('subscribe response', response)
+              document.getElementById("subscribe-inputs").style.display = 'none'
+              document.getElementById("subscribe-confirmation").style.display = 'block'
             },
-            error: function(err) {
-              console.log('err', err)
+            error: function(error) {
+              console.log('subscribe error', error)
             }
           })
         }

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -98,7 +98,31 @@
     </main>
     <div class="subscribe-cta">
       <label>Subscribe for Democracy</label>
-      <input type="text" placeholder="Email Address" /><input type="submit" value="Subscribe" />
+      <input type="text" placeholder="Email Address" id="voter-email" /><input type="submit" value="Subscribe" id="btn-subscribe" onclick="subscribeButton()" />
+      <script>
+        function subscribeButton () {
+          const voterEmail = document.getElementById('voter-email').value
+          console.log(voterEmail)
+
+          return $.ajax({
+            url: 'https://api.liquid.vote/subscribe',
+            type: 'POST',
+            accept: 'application/json',
+            contentType: 'application/json',
+            data: JSON.stringify({
+              email: voterEmail.value
+            }),
+            dataType: 'json',
+            processData: false,
+            success: function(res) {
+              console.log('res', res)
+            },
+            error: function(err) {
+              console.log('err', err)
+            }
+          })
+        }
+      </script>
     </div>
     <div class="bottom-closer">
       <div class="background-closer-image" {%if site.cover %} style="background-image: url({{ site.cover }})"{% endif %}>

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -97,7 +97,7 @@
       </article>
     </main>
     <div class="subscribe-cta">
-      <label>Subscribe for Democracy</label>
+      <label>Subscribe for Updates</label>
       <div id="subscribe-inputs">
         <input type="text" placeholder="Email Address" id="voter-email" /><input type="submit" value="Subscribe" id="btn-subscribe" onclick="subscribeButton()" />
       </div>
@@ -120,6 +120,14 @@
             },
             error: function(error) {
               console.log('subscribe error', error)
+              if (error.status === 409) {
+                // Already subscribed, show confirmation anyway
+                document.getElementById("subscribe-inputs").style.display = 'none'
+                document.getElementById("subscribe-confirmation").style.display = 'block'
+              }
+              if (error.status === 400) {
+                document.getElementById("voter-email").style.border = '1px solid red'
+              }
             }
           })
         }

--- a/css/main.sass
+++ b/css/main.sass
@@ -539,6 +539,36 @@ body
     &:hover
       color: #333
 
+.subscribe-cta
+  background-color: rgba(186,179,162,0.4)
+  text-align: center
+  padding: 37px 0 52px
+  label
+    display: block
+    font-size: 23px
+    letter-spacing: -0.5px
+    margin-bottom: 25px
+  input[type="text"]
+    box-sizing: border-box
+    height: 40px
+    width: 240px
+    padding-left: 12px
+    font-weight: bold
+    font-size: 12px
+    border-width: 0
+    border-radius: 2px
+  input[type="submit"]
+    box-sizing: border-box
+    height: 40px
+    border: none
+    background-color: #2b71b1
+    color: white
+    text-transform: uppercase
+    font-weight: bold
+    padding: 0 12px
+    border-radius: 2px
+
+
 .bottom-closer
   width: 100%
   position: relative

--- a/css/main.sass
+++ b/css/main.sass
@@ -557,6 +557,11 @@ body
     font-size: 12px
     border-width: 0
     border-radius: 2px
+    color: #2f2f2f
+    &:focus
+      border-color: #66afe9
+      outline: 0
+      box-shadow: inset 0 1px 1px rgba(0,0,0,0.075),0 0 8px rgba(102,175,233,0.9)
   input[type="submit"]
     box-sizing: border-box
     height: 40px
@@ -567,6 +572,10 @@ body
     font-weight: bold
     padding: 0 12px
     border-radius: 2px
+    &:hover
+      background-color: #16548E
+      cursor: pointer
+    &:active
 
 
 .bottom-closer

--- a/css/main.sass
+++ b/css/main.sass
@@ -626,14 +626,17 @@ body
     .btn
       display: inline-block
       text-align: center
-      font-size: 15px
+      font-size: 13px
+      font-weight: 600
       text-decoration: none
-      background: #333f86
+      background: #2b71b1
       color: #fff
       border-radius: 999em
       line-height: 44px
       padding: 0 18px
-      border: 1px solid rgba(255,255,255,0.3)
+      &:hover
+        background: #16548E
+        cursor: pointer
 
 #disqus_thread
   margin-top: 50px


### PR DESCRIPTION
Closes #17 

This adds a call-to-action at the end of blog posts to "Subscribe for updates" by email. This sends the email address to the API and sends the Welcome Email if it's not a duplicate.
- Has a success animation
- Has error handling animation
- Also tweaks the `< Back home` button at the very bottom of posts to more closely match the `Subscribe` button's style

Old:

<img width="1370" alt="screen shot 2016-10-28 at 10 24 59 am" src="https://cloud.githubusercontent.com/assets/6340841/19815696/edfcc6b2-9cf8-11e6-8c85-dc7896e6c93c.png">

New:

<img width="1205" alt="screen shot 2016-10-28 at 10 20 39 am" src="https://cloud.githubusercontent.com/assets/6340841/19815575/64e5cda6-9cf8-11e6-833a-bcdf90f42d7d.png">
