### PR TITLE
Make social share icons more visible

### DIFF
--- a/css/main.sass
+++ b/css/main.sass
@@ -534,6 +534,7 @@ body
     text-decoration: none
     color: #bbb
     padding-left: 12px
+    font-size: 30px
     .hidden
       display: none
     &:hover


### PR DESCRIPTION
Old:

<img width="1000" alt="screen shot 2016-10-28 at 10 41 35 am" src="https://cloud.githubusercontent.com/assets/6340841/19816199/3489941e-9cfb-11e6-9812-62626e0812dc.png">

New:

<img width="1000" alt="screen shot 2016-10-28 at 10 40 36 am" src="https://cloud.githubusercontent.com/assets/6340841/19816201/3916b9d0-9cfb-11e6-8655-32ff79b4b207.png">
